### PR TITLE
fix: reject unsupported wire versions

### DIFF
--- a/construct.go
+++ b/construct.go
@@ -25,10 +25,14 @@ type Components struct {
 
 // NewFromParts builds an OrderlyID from explicit component values.
 //
-// NewFromParts may return an error wrapping ErrInvalidPrefix.
+// NewFromParts may return an error wrapping ErrInvalidPrefix or
+// ErrUnsupportedVersion.
 func NewFromParts(c Components, withChecksum bool) (string, error) {
 	if err := validatePrefix(c.Prefix); err != nil {
 		return "", err
+	}
+	if wireVersion(c.Flags) != supportedWireVersion {
+		return "", fmt.Errorf("%w: %d", ErrUnsupportedVersion, wireVersion(c.Flags))
 	}
 	// Convert absolute time to ms since 2020-01-01 UTC (epoch2020).
 	var msSince2020 uint64
@@ -54,8 +58,8 @@ func NewFromParts(c Components, withChecksum bool) (string, error) {
 // NewFromPartsHex builds an OrderlyID from explicit component values and a
 // big-endian random value encoded as hex.
 //
-// NewFromPartsHex may return an error wrapping ErrInvalidPrefix or
-// ErrInvalidRandomHex.
+// NewFromPartsHex may return an error wrapping ErrInvalidPrefix,
+// ErrInvalidRandomHex, or ErrUnsupportedVersion.
 func NewFromPartsHex(c Components, randomHex string, withChecksum bool) (string, error) {
 	rb, err := hex.DecodeString(randomHex)
 	if err != nil {

--- a/orderlyid.go
+++ b/orderlyid.go
@@ -80,6 +80,8 @@ var (
 	ErrInvalidBase32 = errors.New("orderlyid: invalid base32")
 	// ErrInvalidRandomHex reports invalid random hex input passed to NewFromPartsHex.
 	ErrInvalidRandomHex = errors.New("orderlyid: invalid random hex")
+	// ErrUnsupportedVersion reports OrderlyIDs with unsupported wire version bits.
+	ErrUnsupportedVersion = errors.New("orderlyid: unsupported wire version")
 )
 
 func init() {
@@ -108,9 +110,9 @@ func init() {
 }
 
 const (
-	versionBits          = 0 // v1
-	privacyBitMask       = 1 << 5
-	epoch2020      int64 = 1577836800000 // 2020-01-01T00:00:00Z in ms
+	supportedWireVersion       = 0 // v1
+	privacyBitMask             = 1 << 5
+	epoch2020            int64 = 1577836800000 // 2020-01-01T00:00:00Z in ms
 )
 
 var (
@@ -200,7 +202,8 @@ type Parsed struct {
 // Parse decodes an OrderlyID string and returns its components.
 //
 // Parse may return errors wrapping ErrInvalidFormat, ErrInvalidPrefix,
-// ErrInvalidChecksum, ErrInvalidPayloadLength, or ErrInvalidBase32.
+// ErrInvalidChecksum, ErrInvalidPayloadLength, ErrInvalidBase32, or
+// ErrUnsupportedVersion.
 func Parse(s string) (*Parsed, error) {
 	s = strings.TrimSpace(s)
 	base := s
@@ -242,6 +245,9 @@ func Parse(s string) (*Parsed, error) {
 		return nil, err
 	}
 	ms, flags, tenant, seq, shard, random60 := unpack(buf)
+	if wireVersion(flags) != supportedWireVersion {
+		return nil, fmt.Errorf("%w: %d", ErrUnsupportedVersion, wireVersion(flags))
+	}
 	return &Parsed{
 		Prefix: prefix,
 		TimeMs: int64(ms) + epoch2020,
@@ -251,6 +257,10 @@ func Parse(s string) (*Parsed, error) {
 		Shard:  shard,
 		Random: random60,
 	}, nil
+}
+
+func wireVersion(flags byte) byte {
+	return flags >> 6
 }
 
 // Packing layout (big-endian)

--- a/orderlyid_test.go
+++ b/orderlyid_test.go
@@ -119,11 +119,30 @@ func TestParseInvalidChecksumBaseDoesNotPanic(t *testing.T) {
 	}
 }
 
+func TestParseRejectsUnsupportedWireVersion(t *testing.T) {
+	body := pack(0, 0x40, 0, 0, 0, 0)
+	id := "order_" + b32encode(body[:])
+
+	_, err := Parse(id)
+	if err == nil {
+		t.Fatalf("expected unsupported version error")
+	}
+	if !errors.Is(err, ErrUnsupportedVersion) {
+		t.Fatalf("expected ErrUnsupportedVersion, got %v", err)
+	}
+}
+
 func TestNewFromPartsErrorsSupportErrorsIs(t *testing.T) {
 	if _, err := NewFromParts(Components{Prefix: "Bad!"}, false); err == nil {
 		t.Fatalf("expected invalid prefix error")
 	} else if !errors.Is(err, ErrInvalidPrefix) {
 		t.Fatalf("expected ErrInvalidPrefix, got %v", err)
+	}
+
+	if _, err := NewFromParts(Components{Prefix: "order", Flags: 0x40}, false); err == nil {
+		t.Fatalf("expected unsupported version error")
+	} else if !errors.Is(err, ErrUnsupportedVersion) {
+		t.Fatalf("expected ErrUnsupportedVersion, got %v", err)
 	}
 
 	if _, err := NewFromPartsHex(Components{Prefix: "order"}, "zz", false); err == nil {


### PR DESCRIPTION
## Summary

Reject OrderlyIDs whose wire version bits are not supported by the v1 parser instead of decoding them as v1 semantic fields.

This change:

  * adds ErrUnsupportedVersion for version-bit validation failures
  * validates parsed flags before returning v1 component fields
  * rejects unsupported version flags in explicit component constructors
  * adds regression coverage for parse and constructor paths

Tests:

  * `go test ./...`

Refs #11